### PR TITLE
deprecate old updateString that doesn't use Call object

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
 
   <title>Pret Allez</title>
   <script src="rightofway.js"></script>
-  <script src="player.js"></script>
-  <script src="https://www.youtube.com/iframe_api"></script>
+  <!-- <script src="player.js"></script> -->
+  <!-- <script src="https://www.youtube.com/iframe_api"></script> -->
 </head>
 
 <body>
@@ -46,9 +46,9 @@
 
         <div class="rightofway" align="center">
           <h1>Prêt Allez</h1>
-          <br>
+          <!-- <br>
           <div id="player"></div>
-          <br>
+          <br> -->
           <p class="lead" id="userPrompt"></p>
           <div id="buttons"></div>
           <br>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
 
   <title>Pret Allez</title>
   <script src="rightofway.js"></script>
+  <script src="player.js"></script>
+  <script src="https://www.youtube.com/iframe_api"></script>
 </head>
 
 <body>
@@ -44,6 +46,9 @@
 
         <div class="rightofway" align="center">
           <h1>Prêt Allez</h1>
+          <br>
+          <div id="player"></div>
+          <br>
           <p class="lead" id="userPrompt"></p>
           <div id="buttons"></div>
           <br>

--- a/player.js
+++ b/player.js
@@ -1,0 +1,34 @@
+// 3. This function creates an <iframe> (and YouTube player)
+//    after the API code downloads.
+let player;
+function onYouTubeIframeAPIReady() {
+  player = new YT.Player('player', {
+    height: '390',
+    width: '640',
+    videoId: 'jUrpT9VEl4c',
+    events: {
+      'onReady': onPlayerReady,
+      'onStateChange': onPlayerStateChange
+    }
+  });
+}
+
+// 4. The API will call this function when the video player is ready.
+function onPlayerReady(event) {
+  event.target.playVideo();
+}
+
+// 5. The API calls this function when the player's state changes.
+//    The function indicates that when playing a video (state=1),
+//    the player should play for six seconds and then stop.
+let done = false;
+function onPlayerStateChange(event) {
+  if (event.data == YT.PlayerState.PLAYING && !done) {
+    setTimeout(stopVideo, 6000);
+    done = true;
+  }
+}
+
+function stopVideo() {
+  player.stopVideo();
+}

--- a/player.js
+++ b/player.js
@@ -15,7 +15,7 @@ function onYouTubeIframeAPIReady() {
 
 // 4. The API will call this function when the video player is ready.
 function onPlayerReady(event) {
-  event.target.playVideo();
+  // event.target.playVideo();
 }
 
 // 5. The API calls this function when the player's state changes.
@@ -23,10 +23,10 @@ function onPlayerReady(event) {
 //    the player should play for six seconds and then stop.
 let done = false;
 function onPlayerStateChange(event) {
-  if (event.data == YT.PlayerState.PLAYING && !done) {
-    setTimeout(stopVideo, 6000);
-    done = true;
-  }
+  // if (event.data == YT.PlayerState.PLAYING && !done) {
+  //   setTimeout(stopVideo, 6000);
+  //   done = true;
+  // }
 }
 
 function stopVideo() {

--- a/rightofway.js
+++ b/rightofway.js
@@ -164,7 +164,6 @@ function reset() {
   document.getElementById("result").innerHTML = "<strong>Referee calls:</strong> ";
   userCall = new Call();
   updatePriority("none");
-  oldResult = ""; //for testing only
   initial();
 }
 
@@ -187,26 +186,21 @@ function initial() {
 function initialUpdate(event) {
   document.getElementById("result").style.visibility = "visible";
   if (event.target.id === "attackleft") {
-      updateResult(event.target.value + " ");
       updatePriority("left");
       attackResult("attack");
   } else if (event.target.id === "attackright") {
-      updateResult(event.target.value + " ");
       updatePriority("right");
       attackResult("attack");
   } else if (event.target.id ===  "polleft") {
       userCall.actions.push(new PointInLine("left"));
-      updateResult(event.target.value + ", ");
       updatePriority("left");
       awardTouch();
   } else if (event.target.id === "polright") {
       userCall.actions.push(new PointInLine("right"));
-      updateResult(event.target.value + ", ");
       updatePriority("right");
       awardTouch();
   } else if (event.target.id === "simul") {
       userCall.actions.push(new Simultaneous());
-      updateResult(event.target.value + ", ");
       noTouch();
   } else {
       console.log("Error: check if statements in initialUpdate");
@@ -219,7 +213,7 @@ function initialUpdate(event) {
  */
 function attackResult(attackType) {
   userCall.actions.push(new Action(attackType, currentPriority()));
-  updateResult("");
+  updateResult();
   document.getElementById("userPrompt").innerHTML = "What was the result of the " + attackType + "?";
   let b = document.getElementById("attackButtons");
   let actions;
@@ -256,30 +250,30 @@ function attackUpdate(event) {
   let currentAction = userCall.actions[userCall.actions.length - 1];
   if (event.target.id === "arrives") {
     currentAction.result = "arrives";
-    updateResult("arrives, ");
+    updateResult();
     awardTouch();
   } else if (event.target.id === "offtarget") {
     currentAction.result = "is off target";
-    updateResult("is off target, ");
+    updateResult();
     noTouch();
   } else if (event.target.id === "misses") {
     currentAction.result = "is no";
-    updateResult("is no, ");
+    updateResult();
     switchPriority();
     defenderResponse();
   } else if (event.target.id === "misses2nd") {
     currentAction.result = "is no";
-    updateResult("is no, ");
+    updateResult();
     switchPriority();
     attackContinuation();
   } else if (event.target.id === "parried") {
     currentAction.result = "is parried";
-    updateResult("is parried, ");
+    updateResult();
     switchPriority();
     riposte();
   } else if (event.target.id === "counterparried") {
     currentAction.result = "is counterparried";
-    updateResult("is counterparried, ");
+    updateResult();
     switchPriority();
     riposte();
   } else {
@@ -299,11 +293,11 @@ function riposte() {
  */
 function riposteUpdate(event) {
   if (event.target.id === "y") {
-    updateResult("riposte ");
+    updateResult();
     attackResult("riposte");
   } else if (event.target.id === "n") {
     userCall.actions.push(new NoRiposte(currentPriority()));
-    updateResult("no riposte, ");
+    updateResult();
     switchPriority();
     attackContinuation();
   }
@@ -321,7 +315,7 @@ function defenderResponse() {
  */
 function defenderUpdate(event) {
   if (event.target.id === "y") {
-    updateResult("counterattack ");
+    updateResult();
     attackResult("counterattack");
   } else if (event.target.id === "n") {
     switchPriority();
@@ -344,7 +338,7 @@ function attackContinuation() {
  */
 function continuationUpdate(event) {
   if (event.target.id === "remise") {
-    updateResult("remise ");
+    updateResult();
     attackResult("remise");
   } else if (event.target.id === "no") {
     updatePriority("none");
@@ -355,13 +349,13 @@ function continuationUpdate(event) {
 /** Ends the current fencing phrase with a touch to the fencer with priority. */
 function awardTouch() {
   userCall.result = currentPriority();
-  updateResult("touch " + currentPriority() + ".");
+  updateResult();
   showResult();
 }
 
 /** Ends the current fencing phrase with no touch to either fencer. */
 function noTouch() {
-  updateResult("no touch.");
+  updateResult();
   showResult();
 }
 
@@ -372,7 +366,7 @@ function showResult() {
   document.getElementById("buttons").style.visibility = "hidden";
   document.getElementById("priority").style.visibility = "hidden";
   document.getElementById("result").style.visibility = "visible";
-  console.log(userCall);
+  // console.log(userCall);
 }
 
  /**
@@ -447,11 +441,7 @@ function currentPriority() {
   }
 }
 
-let oldResult = "";
-
 /** Updates the result displayed in the "result" element. */
 function updateResult(action) {
   document.getElementById("result").innerHTML = "<strong>Referee calls:</strong> " + userCall.toString();
-  oldResult += action;
-  console.log(oldResult);
 }

--- a/rightofway.js
+++ b/rightofway.js
@@ -17,9 +17,9 @@ Call.prototype.toString = function() {
       result += this.actions[i].toString() + ", ";
     }
 
-    // end the last action with a period
+    // don't end the last action with a comma
     if (i < this.actions.length) {
-      result += this.actions[i].toString() + ". ";
+      result += this.actions[i].toString();
     }
 
     // capitalize first action
@@ -28,11 +28,11 @@ Call.prototype.toString = function() {
     // announce the result of the call if call is completely constructed
     if (this.done()) {
       if (this.result === "left") {
-        result += "Touch left.";
+        result += ". Touch left.";
       } else if (this.result === "right") {
-        result += "Touch right.";
+        result += ". Touch right.";
       } else {
-        result += "No touch."
+        result += ". No touch."
       }
     }
   }
@@ -155,7 +155,7 @@ NoRiposte.prototype.toString = function() {
 /** Global variable for the current user-inputted call. */
 let userCall = new Call();
 
-/** Resets the buttons to the initial state. */
+/** Resets the user interface to the initial state. */
 function reset() {
   document.getElementById("userPrompt").style.visibility = "visible";
   document.getElementById("buttons").style.visibility = "visible";

--- a/rightofway.js
+++ b/rightofway.js
@@ -250,11 +250,9 @@ function attackUpdate(event) {
   let currentAction = userCall.actions[userCall.actions.length - 1];
   if (event.target.id === "arrives") {
     currentAction.result = "arrives";
-    updateResult();
     awardTouch();
   } else if (event.target.id === "offtarget") {
     currentAction.result = "is off target";
-    updateResult();
     noTouch();
   } else if (event.target.id === "misses") {
     currentAction.result = "is no";

--- a/rightofway.js
+++ b/rightofway.js
@@ -25,13 +25,15 @@ Call.prototype.toString = function() {
     // capitalize first action
     result = result.charAt(0).toUpperCase() + result.substring(1);
 
-    // announce the result of the call
-    if (this.result === "left") {
-      result += "Touch left.";
-    } else if (this.result === "right") {
-      result += "Touch right.";
-    } else {
-      result += "No touch."
+    // announce the result of the call if call is completely constructed
+    if (this.done()) {
+      if (this.result === "left") {
+        result += "Touch left.";
+      } else if (this.result === "right") {
+        result += "Touch right.";
+      } else {
+        result += "No touch."
+      }
     }
   }
   return result;
@@ -59,9 +61,12 @@ Call.prototype.equals = function(anotherCall) {
 Call.prototype.done = function() {
   if (this.actions.length === 0) {
     return false;
-  }
-  for (let i = 0; i < this.actions.length; i++) {
-
+  } else if (this.actions[0] instanceof Simultaneous ||
+            this.actions[0] instanceof PointInLine) {
+    return true;
+  } else {
+    let lastAction = this.actions[this.actions.length - 1];
+    return lastAction.result === "arrives" || lastAction.result === "is off target";
   }
 }
 

--- a/rightofway.js
+++ b/rightofway.js
@@ -3,7 +3,7 @@
  */
 function Call() {
   this.actions = [];
-  this.result = "none";
+  this.result = "";
 }
 
 /** String representation of this Call.
@@ -16,16 +16,25 @@ Call.prototype.toString = function() {
     for (i = 0; i < this.actions.length - 1; i++) {
       result += this.actions[i].toString() + ", ";
     }
-    result += this.actions[i].toString() + ". ";
-    if (this.result === "left") {
-      result += "touch left.";
-    } else if (this.result === "right") {
-      result += "touch right.";
-    } else {
-      result += "no touch."
+
+    // end the last action with a period
+    if (i < this.actions.length) {
+      result += this.actions[i].toString() + ". ";
     }
-    return result;
+
+    // capitalize first action
+    result = result.charAt(0).toUpperCase() + result.substring(1);
+
+    // announce the result of the call
+    if (this.result === "left") {
+      result += "Touch left.";
+    } else if (this.result === "right") {
+      result += "Touch right.";
+    } else {
+      result += "No touch."
+    }
   }
+  return result;
 }
 
 /** Checks whether one Call is the same as another Call.
@@ -44,6 +53,18 @@ Call.prototype.equals = function(anotherCall) {
   return true;
 }
 
+/** Returns whether this call represents a complete fencing phrase.
+ * @returns {boolean}
+ */
+Call.prototype.done = function() {
+  if (this.actions.length === 0) {
+    return false;
+  }
+  for (let i = 0; i < this.actions.length; i++) {
+
+  }
+}
+
 /** Object representing a single fencing action.
  * @constructor
  * @param {string} type - the kind of action, e.g. "attack", "riposte", etc.
@@ -56,7 +77,7 @@ Call.prototype.equals = function(anotherCall) {
 function Action(type, fencer, result) {
   this.type = type;
   this.fencer = fencer;
-  this.result = result || "none";
+  this.result = result || "";
 }
 
 /** String representation of this action.
@@ -84,6 +105,7 @@ function PointInLine(fencer) {
   Action.call(this, "point-in-line", fencer, "arrives");
 }
 
+/** PointInLine extends Action */
 PointInLine.prototype = Object.create(Action.prototype);
 
 /** Represents simultaneous attacks, a special kind of Action.
@@ -93,6 +115,7 @@ function Simultaneous() {
   Action.call(this, "simultaneous", "none", "none");
 }
 
+/** Simultaneous extends Action */
 Simultaneous.prototype = Object.create(Action.prototype);
 
 /** String representation of simultaneous has no attached fencer or result.
@@ -176,7 +199,8 @@ function attackResult(attackType) {
       "arrives": attackType + " arrives",
        "offtarget": attackType + " off target",
        "misses": attackType + " misses",
-       "parried": attackType + " is parried"};
+       "parried": attackType + " is parried"
+     };
   } else if (attackType === "counterattack") {
      actions = {
        "arrives": attackType + " arrives",
@@ -202,31 +226,31 @@ function attackUpdate(event) {
   // document.getElementById("result").style.visibility = "visible";
   let currentAction = userCall.actions[userCall.actions.length - 1];
   if (event.target.id === "arrives") {
-    updateResult("arrives, ");
     currentAction.result = "arrives";
+    updateResult("arrives, ");
     awardTouch();
   } else if (event.target.id === "offtarget") {
+    currentAction.result = "is off target";
     updateResult("is off target, ");
-    currentAction.result = "off target";
     noTouch();
   } else if (event.target.id === "misses") {
-    updateResult("is no, ");
     currentAction.result = "is no";
+    updateResult("is no, ");
     switchPriority();
     defenderResponse();
   } else if (event.target.id === "misses2nd") {
-    updateResult("is no, ");
     currentAction.result = "is no";
+    updateResult("is no, ");
     switchPriority();
     attackContinuation();
   } else if (event.target.id === "parried") {
+    currentAction.result = "is parried";
     updateResult("is parried, ");
-    currentAction.result = "parried";
     switchPriority();
     riposte();
   } else if (event.target.id === "counterparried") {
+    currentAction.result = "is counterparried";
     updateResult("is counterparried, ");
-    currentAction.result = "counterparried";
     switchPriority();
     riposte();
   } else {

--- a/rightofway.js
+++ b/rightofway.js
@@ -105,6 +105,8 @@ Action.prototype.equals = function(anotherAction) {
 
 /** Represents a point-in-line, a special kind of Action.
  * @constructor
+ * @param {string} fencer - either "left" or "right": the fencer that performed
+                            this action
  */
 function PointInLine(fencer) {
   Action.call(this, "point-in-line", fencer, "arrives");
@@ -130,6 +132,26 @@ Simultaneous.prototype.toString = function() {
   return this.type;
 }
 
+/** Represents a lack of riposte following a parry.
+ * @constructor
+ * @param {string} fencer - either "left" or "right": the fencer that performed
+                            this action
+ */
+function NoRiposte(fencer) {
+  Action.call(this, "no riposte", fencer, "");
+}
+
+/** NoRiposte extends Action */
+NoRiposte.prototype = Object.create(Action.prototype);
+
+/** String representation of no riposte has no result; the fencer in question
+ * is easily identifiable from the previous action.
+ * @override
+ */
+NoRiposte.prototype.toString = function() {
+  return this.type;
+}
+
 /** Global variable for the current user-inputted call. */
 let userCall = new Call();
 
@@ -142,6 +164,7 @@ function reset() {
   document.getElementById("result").innerHTML = "<strong>Referee calls:</strong> ";
   userCall = new Call();
   updatePriority("none");
+  oldResult = ""; //for testing only
   initial();
 }
 
@@ -196,6 +219,7 @@ function initialUpdate(event) {
  */
 function attackResult(attackType) {
   userCall.actions.push(new Action(attackType, currentPriority()));
+  updateResult("");
   document.getElementById("userPrompt").innerHTML = "What was the result of the " + attackType + "?";
   let b = document.getElementById("attackButtons");
   let actions;
@@ -278,6 +302,7 @@ function riposteUpdate(event) {
     updateResult("riposte ");
     attackResult("riposte");
   } else if (event.target.id === "n") {
+    userCall.actions.push(new NoRiposte(currentPriority()));
     updateResult("no riposte, ");
     switchPriority();
     attackContinuation();
@@ -422,10 +447,11 @@ function currentPriority() {
   }
 }
 
-/** Updates the result displayed in the "result" element.
- * NOTE: Possibly could be superseded by the Call object's toString method in future.
- */
+let oldResult = "";
+
+/** Updates the result displayed in the "result" element. */
 function updateResult(action) {
-  document.getElementById("result").innerHTML += action;
-  console.log(userCall.toString());
+  document.getElementById("result").innerHTML = "<strong>Referee calls:</strong> " + userCall.toString();
+  oldResult += action;
+  console.log(oldResult);
 }


### PR DESCRIPTION
Originally the `updateString()` function added a string directly to the `result` HTML element, and the string was passed directly into the function as a parameter. Now that I'm updating a Call object every time the user adds new Action objects, I can simply use the `toString()` method of the Call object to construct the string each time. This should allow me to more easily modify the user interface if I intend to change the design of the result screen sometime in the future.